### PR TITLE
Allow stream input for accepting functions

### DIFF
--- a/automata-doc/scribblings/automata.scrbl
+++ b/automata-doc/scribblings/automata.scrbl
@@ -40,12 +40,12 @@ Identifies accepting machines.
 
 @defproc[(machine-accepting [guts any/c] [next (-> any/c machine?)]) machine?]{Constructs an accepting machine.}
 
-@defproc[(machine-accepts? [m machine?] [i (listof any/c)])
+@defproc[(machine-accepts? [m machine?] [i stream?])
          boolean?]{
  Returns @racket[#t] if @racket[m] ends in an accepting state after consuming every element of @racket[i].
 }
 
-@defproc[(machine-accepts?/prefix-closed [m machine?] [i (listof any/c)])
+@defproc[(machine-accepts?/prefix-closed [m machine?] [i stream?])
          boolean?]{
  Returns @racket[#t] if @racket[m] stays in an accepting state during the consumption of every element of @racket[i].
 }

--- a/automata-lib/machine.rkt
+++ b/automata-lib/machine.rkt
@@ -1,6 +1,6 @@
 #lang racket/base
 (require racket/contract
-         racket/list)
+         racket/stream)
 
 (struct machine (guts next)
         #:mutable
@@ -108,15 +108,15 @@
   m)
 
 (define (machine-accepts? m evts)
-  (if (empty? evts)
+  (if (stream-empty? evts)
       (machine-accepting? m)
-      (machine-accepts? (m (first evts)) (rest evts))))
+      (machine-accepts? (m (stream-first evts)) (stream-rest evts))))
 (define (machine-accepts?/prefix-closed m evts)
-  (if (empty? evts)
+  (if (stream-empty? evts)
       (machine-accepting? m)
-      (let ([n (m (first evts))])
+      (let ([n (m (stream-first evts))])
         (and (machine-accepting? n)
-             (machine-accepts? n (rest evts))))))
+             (machine-accepts? n (stream-rest evts))))))
 
 (define machine-null
   (machine 'null (λ (input) machine-null)))
@@ -158,8 +158,8 @@
          machine-accepting)
 (provide/contract*
  [machine-explain (machine? . -> . any/c)]
- [machine-accepts? (machine? (listof any/c) . -> . boolean?)]
- [machine-accepts?/prefix-closed (machine? (listof any/c) . -> . boolean?)]
+ [machine-accepts? (machine? stream? . -> . boolean?)]
+ [machine-accepts?/prefix-closed (machine? stream? . -> . boolean?)]
  #;[struct machine ([next (any/c . -> . machine?)])]
  #;[struct (machine-accepting machine) ([next (any/c . -> . machine?)])]
  [machine-null machine?]


### PR DESCRIPTION
I needed to match against a general stream and not a list. Seems like the library uses only `first`, `rest`, and `empty?` of the list input, so it can easily be a stream. Generalizing the accepting functions should make the library a bit more versatile.